### PR TITLE
docs: fix symbol name in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Checklists are incredibly useful for keeping track of important items. We can us
 - [ ] Neptune
 - [ ] Comet Haley
 
-#show: checklist.with(marker-map: (" ": sym.ballot, "x": sym.ballot.x, "-": sym.bar.h, "/": sym.slash.double))
+#show: checklist.with(marker-map: (" ": sym.ballot, "x": sym.ballot.cross, "-": sym.bar.h, "/": sym.slash.double))
 
 = Solar System Exploration, 1950s – 1960s
 
@@ -100,7 +100,7 @@ Checklists are incredibly useful for keeping track of important items. We can us
 - `fill`: [`string`] &mdash; The fill color for the checklist marker.
 - `stroke`: [`string`] &mdash; The stroke color for the checklist marker.
 - `radius`: [`string`] &mdash; The radius of the checklist marker.
-- `marker-map`: [`map`] &mdash; The map of the checklist marker. It should be a map of character to symbol function, such as `(" ": sym.ballot, "x": sym.ballot.x, "-": sym.bar.h, "/": sym.slash.double)`.
+- `marker-map`: [`map`] &mdash; The map of the checklist marker. It should be a map of character to symbol function, such as `(" ": sym.ballot, "x": sym.ballot.cross, "-": sym.bar.h, "/": sym.slash.double)`.
 - `show-list-set-block`: [`dictionary`] - The configuration of the block in list. It should be a dictionary of `above` and `below` keys, such as `(above: .5em)`.
 - `body`: [`content`] &mdash; The main body from `#show: checklist` rule.
 

--- a/examples/custom-styles.typ
+++ b/examples/custom-styles.typ
@@ -16,7 +16,7 @@
 - [ ] Neptune
 - [ ] Comet Haley
 
-#show: checklist.with(marker-map: (" ": sym.ballot, "x": sym.ballot.x, "-": sym.bar.h, "/": sym.slash.double))
+#show: checklist.with(marker-map: (" ": sym.ballot, "x": sym.ballot.cross, "-": sym.bar.h, "/": sym.slash.double))
 
 = Solar System Exploration, 1950s – 1960s
 

--- a/lib.typ
+++ b/lib.typ
@@ -76,7 +76,7 @@
 /// - `fill`: [`string`] - The fill color for the checklist marker.
 /// - `stroke`: [`string`] - The stroke color for the checklist marker.
 /// - `radius`: [`string`] - The radius of the checklist marker.
-/// - `marker-map`: [`map`] - The map of the checklist marker. It should be a map of character to symbol function, such as `(" ": sym.ballot, "x": sym.ballot.x, "-": sym.bar.h, "/": sym.slash.double)`.
+/// - `marker-map`: [`map`] - The map of the checklist marker. It should be a map of character to symbol function, such as `(" ": sym.ballot, "x": sym.ballot.cross, "-": sym.bar.h, "/": sym.slash.double)`.
 /// - `show-list-set-block`: [`dictionary`] - The configuration of the block in list. It should be a dictionary of `above` and `below` keys, such as `(above: .5em)`.
 /// - `body`: [`content`] - The main body from `#show: checklist` rule.
 ///


### PR DESCRIPTION
In issue #6, the wrong symbol name was reported.
This PR replaces `sym.ballot.x` with `sym.ballot.cross`.