### PR TITLE
fixes numbering bug

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -278,11 +278,8 @@
 
     if is-checklist {
       if not ("html" in dictionary(std) and target() == "html") {
-        let checklist-enumeration(n) = {
-          symbols-list.at(n - 1)
-        }
         enum(
-          numbering: checklist-enumeration,
+          numbering: (n,..) => {symbols-list.at(n - 1)},
           tight: it.tight,
           indent: it.indent,
           body-indent: it.body-indent,

--- a/lib.typ
+++ b/lib.typ
@@ -279,7 +279,7 @@
     if is-checklist {
       if not ("html" in dictionary(std) and target() == "html") {
         enum(
-          numbering: (n,..) => {symbols-list.at(n - 1)},
+          numbering: (.., n) => { symbols-list.at(n - 1) },
           tight: it.tight,
           indent: it.indent,
           body-indent: it.body-indent,


### PR DESCRIPTION
Fixes #11 

When enum is set to full:true, the numbering function is passed more than one argument. The solution is simply to discard the additional variables.