### PR TITLE
Fix radius clipping on incomplete symbol (#16)

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -41,10 +41,10 @@
   height: .8em,
   width: .8em,
   radius: radius,
-  if light{
-    box(move(dy: .4em, dx: 0.0em, rotate(90deg, reflow: false, line(length: 0.8em, stroke: if light {stroke} else {fill} + .07em))))
+  if light {
+    box(move(dy: .4em, dx: .0em, rotate(90deg, reflow: false, line(length: .8em, stroke: stroke + .07em))))
   } else {
-    box(fill: stroke, height: .8em, width: .4em, radius: (top-left: radius, bottom-left: radius))
+    box(stroke: none, height: 100%, width: 100%, radius: radius, clip: true, box(fill: stroke, height: 100%, width: 50%))
   },
 ))
 


### PR DESCRIPTION
# Solves #16

<details><summary>Debug</summary>
<img width="1091" height="1840" alt="debug-1" src="https://github.com/user-attachments/assets/6fd2f8e0-fd60-490a-889a-8aefb6a76460" />
</details>

# Attempt # 1 (failure)

Setting `clip: true` on the outermost `box` created an erroneous hairline white border between the two `box`es.

<details><summary>Example</summary>
<img width="1091" height="1840" alt="black-2" src="https://github.com/user-attachments/assets/2f8af2d7-2e18-4933-85a7-d3107c7a7123" />
</details>
<details><summary>Zoomed in</summary>
<img width="4075" height="953" alt="debug-2" src="https://github.com/user-attachments/assets/c91f18ff-16cc-44bf-b71e-f9a20cd4dbdc" />
</details>

# Attempt # 2 (failure)

Correctly setting `radius: (top-right: radius, bottom-right: radius)` on the inner `box` applies the radius differencly, since the two `box`es are different widths.

<details><summary>Debug</summary>
<img width="1091" height="1840" alt="debug-3" src="https://github.com/user-attachments/assets/51bd1f42-502b-47c8-a9ae-470ab5743f73" />
</details>

# Attempt # 3 (success)

What seems to work best is adding an intermediate `box(clip: true)` between the other two, and ignore the radius altogether on the inner `box`.

<details><summary>Debug</summary>
<img width="1091" height="1840" alt="debug-4" src="https://github.com/user-attachments/assets/561b1588-1840-4f94-a44f-918a3877acc9" />
</details>

<details><summary>Correct colours</summary>
<img width="1091" height="1840" alt="black-4" src="https://github.com/user-attachments/assets/3148bf3d-f414-4e8c-bcc0-f9d6ac2f1ff7" />
</details>
